### PR TITLE
Update UART16550 port names to include direction suffix.

### DIFF
--- a/hardware/simulation/src/iob_uart16550_sim_wrapper.v
+++ b/hardware/simulation/src/iob_uart16550_sim_wrapper.v
@@ -92,10 +92,10 @@ module iob_uart16550_sim_wrapper #(
       .ADDR_W(ADDR_W)   //CPU address section width
    ) uart16550 (
       //RS232 interface
-      .txd(pad_stx_o),
-      .rxd(pad_srx_i),
-      .rts(rts_o),
-      .cts(cts_i),
+      .txd_o(pad_stx_o),
+      .rxd_i(pad_srx_i),
+      .rts_o(rts_o),
+      .cts_i(cts_i),
 
       //CPU interface
       .clk_i       (clk_i),
@@ -109,7 +109,7 @@ module iob_uart16550_sim_wrapper #(
       .iob_rdata_o (m_rdata),
       .iob_ready_o (m_ready),
 
-      .interrupt(uartInterrupt)
+      .interrupt_o(uartInterrupt)
    );
 
 endmodule

--- a/hardware/src/iob_uart16550.v
+++ b/hardware/src/iob_uart16550.v
@@ -58,15 +58,15 @@ module iob_uart16550 #(
       .wb_dat_i (m_wb_dat_req),
       .wb_ack_o (m_wb_ack),
       .wb_dat_o (m_wb_dat_resp),
-      .int_o    (interrupt),
+      .int_o    (interrupt_o),
 `ifdef UART_HAS_BAUDRATE_OUTPUT
       .baud1_o  (),
 `endif
       // UART signals
-      .srx_pad_i(rxd),
-      .stx_pad_o(txd),
-      .rts_pad_o(rts),
-      .cts_pad_i(cts),
+      .srx_pad_i(rxd_i),
+      .stx_pad_o(txd_o),
+      .rts_pad_o(rts_o),
+      .cts_pad_i(cts_i),
       .dtr_pad_o(),
       .dsr_pad_i(1'b1),
       .ri_pad_i (1'b0),

--- a/iob_uart16550.py
+++ b/iob_uart16550.py
@@ -100,25 +100,25 @@ class iob_uart16550(iob_module):
                 "ports": [
                     # {'name':'interrupt', 'type':'O', 'n_bits':'1', 'descr':'be done'},
                     {
-                        "name": "txd",
+                        "name": "txd_o",
                         "type": "O",
                         "n_bits": "1",
                         "descr": "Serial transmit line",
                     },
                     {
-                        "name": "rxd",
+                        "name": "rxd_i",
                         "type": "I",
                         "n_bits": "1",
                         "descr": "Serial receive line",
                     },
                     {
-                        "name": "cts",
+                        "name": "cts_i",
                         "type": "I",
                         "n_bits": "1",
                         "descr": "Clear to send; the destination is ready to receive a transmission sent by the UART",
                     },
                     {
-                        "name": "rts",
+                        "name": "rts_o",
                         "type": "O",
                         "n_bits": "1",
                         "descr": "Ready to send; the UART is ready to receive a transmission from the sender",
@@ -130,7 +130,7 @@ class iob_uart16550(iob_module):
                 "descr": "UART16550 interrupt related signals",
                 "ports": [
                     {
-                        "name": "interrupt",
+                        "name": "interrupt_o",
                         "type": "O",
                         "n_bits": "1",
                         "descr": "UART interrupt source",


### PR DESCRIPTION
- Update interrupt and rs232 ports to include direction suffix, similar to the IOb-UART core.