### PR TITLE
Update `regs` dictionary; Remove LIB.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/LIB"]
-	path = submodules/LIB
-	url = git@github.com:IObundle/iob-lib.git

--- a/iob_uart16550.py
+++ b/iob_uart16550.py
@@ -141,6 +141,7 @@ class iob_uart16550(iob_module):
 
     @classmethod
     def _setup_regs(cls):
+        cls.autoaddr = False
         cls.regs += [
             {
                 "name": "uart16550",

--- a/iob_uart16550.py
+++ b/iob_uart16550.py
@@ -153,7 +153,7 @@ class iob_uart16550(iob_module):
                         "rst_val": 0,
                         "addr": 0x8000,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "Dummy register.",
                     },
                 ],

--- a/software/src/iob-uart16550.c
+++ b/software/src/iob-uart16550.c
@@ -42,9 +42,8 @@ void uart16550_init(int base_address, uint16_t div) {
 
   // Set the Line Control Register to the desired line control parameters.
   // Set bit 7 to ‘1’ to allow access to the Divisor Latches.
-  uint8_t lcr = 3;
-  // Disabled reading from lcr reg, because sometimes it uses wrong value. Not sure why. Maybe reg is not reset correctly?
-  //lcr = *((volatile uint8_t *)(base + 3));
+  uint8_t lcr = 0;
+  lcr = *((volatile uint8_t *)(base + 3));
   lcr = (lcr | 0x80);
   *((volatile uint8_t *)(base + 3)) = lcr;
 

--- a/software/src/iob-uart16550.c
+++ b/software/src/iob-uart16550.c
@@ -42,8 +42,9 @@ void uart16550_init(int base_address, uint16_t div) {
 
   // Set the Line Control Register to the desired line control parameters.
   // Set bit 7 to ‘1’ to allow access to the Divisor Latches.
-  uint8_t lcr = 0;
-  lcr = *((volatile uint8_t *)(base + 3));
+  uint8_t lcr = 3;
+  // Disabled reading from lcr reg, because sometimes it uses wrong value. Not sure why. Maybe reg is not reset correctly?
+  //lcr = *((volatile uint8_t *)(base + 3));
   lcr = (lcr | 0x80);
   *((volatile uint8_t *)(base + 3)) = lcr;
 


### PR DESCRIPTION
~- Update `uart16550_init` function to set the correct initial value for the Line Control Register. The fixed initial value is 0x03. This value should be the same as the reset value from hardware (according to the UART16550 Core Technical Manual). However, if we don't initialize it in software, it seems that the hardware reset value is sometimes not correct. Without this software fix, the uart16550 core would sometimes transmit with 5 bits per character, instead of the correct 8 bits per character. This behaviour was probably due to the wrong init value in the LCR register.~

### Update:
- Update `regs` dictionary;
- Remove LIB.

Used for https://github.com/IObundle/iob-soc-opencryptolinux/pull/53