### PR TITLE
Use hardcoded csrs address width value.

### DIFF
--- a/iob_uart16550.py
+++ b/iob_uart16550.py
@@ -37,10 +37,10 @@ def setup(py_params_dict):
             },
             {
                 "name": "iob_csrs_cbus_s",
-                "descr": "CPU native interface",
+                "descr": "Control and Status Registers interface",
                 "signals": {
                     "type": "iob",
-                    "ADDR_W": "ADDR_W",
+                    "ADDR_W": 5,
                 },
             },
             {


### PR DESCRIPTION
Current py2hwsw's iob_system uses this value to instantiate peripherals with the correct width. It needs to have a integer to set it correctly. Otherwise it may inadvertantly use the "ADDR_W" parameter from iob_system as this value.

Related to PR https://github.com/IObundle/py2hwsw/pull/379