### PR TITLE
Disable malloc from uart16550_recvfile() method.

### DIFF
--- a/software/src/iob_uart16550.c
+++ b/software/src/iob_uart16550.c
@@ -127,14 +127,16 @@ int uart16550_recvfile(char *file_name, char *mem) {
   file_size |= ((unsigned int)uart16550_getc()) << 16;
   file_size |= ((unsigned int)uart16550_getc()) << 24;
 
-  // allocate space for file if file pointer not initialized
-  if (mem == NULL) {
-    mem = (char *)malloc(file_size);
-    if (mem == NULL) {
-      uart16550_puts(UART_PROGNAME);
-      uart16550_puts("Error: malloc failed");
-    }
-  }
+  // Disabled this because we may want to write files starting at address 0 (to
+  // initialize memory of iob_system).
+  // Allocate space for file if file pointer
+  // not initialized if (mem == NULL) {
+  //   mem = (char *)malloc(file_size);
+  //   if (mem == NULL) {
+  //     uart16550_puts(UART_PROGNAME);
+  //     uart16550_puts("Error: malloc failed");
+  //   }
+  // }
 
   // send ACK before receiving file
   uart16550_putc(ACK);


### PR DESCRIPTION
There are cases where we want to receive files starting at address 0 (for example, to initialize the memory of iob_system). The original malloc code would assume address 0 was NULL, and write to another place instead.

The driver of the iob-uart peripheral (https://github.com/IObundle/iob-uart) also does not have this malloc code.