### PR TITLE
fix(nix): Update py2hwsw commit

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "8bbb3ce5c4c654ce69574db0b10372db55b7c73d"; # Replace with the desired commit.
-  py2hwsw_sha256 = "SH/e6uL/gxG4a3ALxSyvmvn530g4TOzZw77OUs2Sxds="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "063b0c34ddbcdf82ba9582ad50a5ae15a3827be0"; # Replace with the desired commit.
+  py2hwsw_sha256 = "xq2u3HTkcpthoLWKqjmsjCqUZWFn+07LpEfutTYx9KU="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 


### PR DESCRIPTION
Update py2hwsw commit to fix nix-shell sha derivations.
Includes fix from PR: https://github.com/IObundle/py2hwsw/pull/408

### Please modify tag [M3_e](https://github.com/IObundle/iob-uart16550/releases/tag/M3_e) to point to latest commit after merging this PR.